### PR TITLE
Add initial authentication button

### DIFF
--- a/assets/javascript/project.js
+++ b/assets/javascript/project.js
@@ -1,0 +1,10 @@
+
+console.log("javascript file is working")
+// build authorization URL.
+  // Question: How do we keep the client ID hidden?
+  // Build Redirect URL: 
+    // Question: Where should the redirect URL be where it will work in test and in production?
+// On click of authorization URL, user is taken to log in.
+// Use response to get an access token, which we can use to make subsequen API requests
+
+var authorizationURL = "https://accounts.spotify.com/authorize?client_id=6ba0c775865d4f34a62198bacaebc943&response_type=token&redirect_uri=https://www.google.com"

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
     <title>Document</title>
 </head>
 <body>
-    
+    <button onclick="window.location.href ='https://accounts.spotify.com/authorize?client_id=6ba0c775865d4f34a62198bacaebc943&response_type=token&redirect_uri=https://www.google.com';">Log in to Spotify</button>
+    <script src="assets/javascript/project.js"></script>
+    <script src="https://code.jquery.com/jquery-3.4.0.min.js" integrity="sha256-BJeo0qm959uMBGb65z40ejJYGSgR7REI4+CW1fNKwOg=" crossorigin="anonymous"></script>
 </body>
 </html>


### PR DESCRIPTION
Authentication is pretty complicated with Spotify but I think this is the first step. 
1. User needs to authenticate on spotify using the Implicit Grant Flow.  If the user grants access, the final URL will contain a hash fragment with the following data encoded as a query string. This can be used in subsequent API calls.