### PR TITLE
Fixed table headers and table row CSS

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -25,8 +25,16 @@ tbody {
     font-size: 18px;
 }
 
+table td
+{
+    text-align: left;
+    vertical-align: middle;
+    padding: 5px;
+    position: relative;
+}
+
 thead {
-    font-size: 22px;
+    font-size: 28px;
     text-align: left;
 }
 

--- a/assets/javascript/project.js
+++ b/assets/javascript/project.js
@@ -104,6 +104,7 @@ $("#search-button").on("click", function() {
         newImgTag.append(newImg);
         newArtist.append(resultArtist);
         var newGenre = $('<td class="genre">');
+        // Styling the items in genres array from Spotify
         for(i = 0; i< response.artists.items[resultNum].genres.length; i++){
           if(resultGenre[i].indexOf(" ") !== -1){
             resultGenre[i] = resultGenre[i].replace(" ", "-");
@@ -115,9 +116,6 @@ $("#search-button").on("click", function() {
             newGenre.append(resultGenre[i].charAt(0).toUpperCase() + resultGenre[i].slice(1) + " | ");
             }
         }
-        // New Popularity Variable
-        var newPopularity = $('<td class="popularity">');
-        newPopularity.append(resultPopularity);
         // var newIdtag = $("<td>");
         // newIdtag.addClass("id");
         // newIdtag.append(resultId);
@@ -125,7 +123,6 @@ $("#search-button").on("click", function() {
         newRow.append(newImg);
         newRow.append(newArtist);
         newRow.append(newGenre);
-        newRow.append(newPopularity);
 
         // Append to HTML
         $('#newTrackRow').append(newRow);

--- a/index.html
+++ b/index.html
@@ -39,12 +39,9 @@
         <!-- Search Results -->
         <table id = "searchTab" class="ui selectable inverted table searchTable">
           <thead>
-            <tr>
               <th class='three wide image'>Image</th>
               <th class='artist'>Artist</th>
               <th class='genre'>Genre</th>
-              <th class='popularity'>Popularity</th>
-            </tr>
           </thead>
           <!-- Tracks Populate Here -->
           <tbody id='newTrackRow'></tbody>
@@ -53,12 +50,13 @@
         <!-- Recommended Tracks -->
         <table id="recommended-artists" class='ui selectable single line inverted table padding'>
           <thead id="thead">
-            <th class='recImg two wide'></th>
-            <th class='recTitle'>Title</th>
+            <th class='three wide image'>Image</th>
+            <th class='three wide recTitle'>Title</th>
             <th class='recArtist'>Artist</th>
             <th class='recAlbum'>Album</th>
           </thead>
-          <tr id='recommendations'></tr>
+          <!-- Recommended Tracks Populate Here -->
+          <tbody id='recommendations'></tbody>
         </table>
       </div>
     


### PR DESCRIPTION
Recommended Table Headers are now aligned properly.

I found what is stopping the first table from extending all the way to the end but didn't want to mess with a lot in this pull request without uploading table fixes. When a 'newRow' is generated, the <tr> tag is getting things appended to it (resultId, .search-result). I think that is creating an extra space in the row. If we can attach the id to the image instead and still have the functionality, that is my best guess of fixing it without rethinking how it's structured.

The content in the rows is now centered. If you type in another query and hit Gimme Tunes, I think we should clear all existing tables. Currently, you search and click on one and get results and if you search again, the old results just stay there while no new ones are generated.
